### PR TITLE
Enable code coverage reporting.

### DIFF
--- a/Example/WordPressApiExample.xcodeproj/xcshareddata/xcschemes/WordPressApiExample.xcscheme
+++ b/Example/WordPressApiExample.xcodeproj/xcshareddata/xcschemes/WordPressApiExample.xcscheme
@@ -40,7 +40,8 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">


### PR DESCRIPTION
This will allows us to better evaluate how much coverage our tests have on the library.

Needs Review: @bummytime 