### PR TITLE
Refactor guess xml function

### DIFF
--- a/Pod/WordPressXMLRPCApi.m
+++ b/Pod/WordPressXMLRPCApi.m
@@ -212,11 +212,8 @@ NSString *const WordPressXMLRPCApiErrorDomain = @"WordPressXMLRPCApiError";
 + (void)guessXMLRPCURLForSite:(NSString *)url
                       success:(void (^)(NSURL *xmlrpcURL))success
                       failure:(void (^)(NSError *error))failure {
-    NSURL *xmlrpcURL;
-    NSString *xmlrpc;
-
     NSError *error = nil;
-    xmlrpcURL = [self urlForXMLRPCFromUrl:url addXMLRPC:YES error:&error];
+    NSURL *xmlrpcURL = [self urlForXMLRPCFromUrl:url addXMLRPC:YES error:&error];
     if (xmlrpcURL == nil) {
         [self logExtraInfo: [error localizedDescription]];
         if (failure) {
@@ -224,7 +221,6 @@ NSString *const WordPressXMLRPCApiErrorDomain = @"WordPressXMLRPCApiError";
         }
         return;
     }
-    xmlrpc = [xmlrpcURL absoluteString];
     [self logExtraInfo: @"Trying the following URL: %@", xmlrpcURL ];
     [self validateXMLRPCUrl:xmlrpcURL success:^(NSURL *validatedXmlrpcURL){
         if (success) {

--- a/Pod/WordPressXMLRPCApi.m
+++ b/Pod/WordPressXMLRPCApi.m
@@ -258,12 +258,7 @@ NSString *const WordPressXMLRPCApiErrorDomain = @"WordPressXMLRPCApiError";
             AFHTTPRequestOperation *operation = [[AFHTTPRequestOperation alloc] initWithRequest:request];
             [operation setCompletionBlockWithSuccess:^(AFHTTPRequestOperation *operation, id responseObject) {
                 NSError *error = NULL;
-                NSString *responseString = operation.responseString;
-                // Workaround for https://github.com/AFNetworking/AFNetworking/pull/638
-                // remove when it's fixed upstream. See http://ios.trac.wordpress.org/ticket/1516
-                if (responseString == nil && operation.responseData != nil) {
-                    responseString = [[NSString alloc] initWithData:operation.responseData encoding:NSISOLatin1StringEncoding];
-                }
+                NSString *responseString = operation.responseString;                
                 NSArray *matches = nil;
                 if (responseString) {
                     NSRegularExpression *rsdURLRegExp = [NSRegularExpression regularExpressionWithPattern:@"<link\\s+rel=\"EditURI\"\\s+type=\"application/rsd\\+xml\"\\s+title=\"RSD\"\\s+href=\"([^\"]*)\"[^/]*/>" options:NSRegularExpressionCaseInsensitive error:&error];

--- a/Pod/WordPressXMLRPCApi.m
+++ b/Pod/WordPressXMLRPCApi.m
@@ -258,7 +258,6 @@ NSString *const WordPressXMLRPCApiErrorDomain = @"WordPressXMLRPCApiError";
             AFHTTPRequestOperation *operation = [[AFHTTPRequestOperation alloc] initWithRequest:request];
             [operation setCompletionBlockWithSuccess:^(AFHTTPRequestOperation *operation, id responseObject) {
                 NSError *error = NULL;
-                NSRegularExpression *rsdURLRegExp = [NSRegularExpression regularExpressionWithPattern:@"<link\\s+rel=\"EditURI\"\\s+type=\"application/rsd\\+xml\"\\s+title=\"RSD\"\\s+href=\"([^\"]*)\"[^/]*/>" options:NSRegularExpressionCaseInsensitive error:&error];
                 NSString *responseString = operation.responseString;
                 // Workaround for https://github.com/AFNetworking/AFNetworking/pull/638
                 // remove when it's fixed upstream. See http://ios.trac.wordpress.org/ticket/1516
@@ -267,6 +266,7 @@ NSString *const WordPressXMLRPCApiErrorDomain = @"WordPressXMLRPCApiError";
                 }
                 NSArray *matches = nil;
                 if (responseString) {
+                    NSRegularExpression *rsdURLRegExp = [NSRegularExpression regularExpressionWithPattern:@"<link\\s+rel=\"EditURI\"\\s+type=\"application/rsd\\+xml\"\\s+title=\"RSD\"\\s+href=\"([^\"]*)\"[^/]*/>" options:NSRegularExpressionCaseInsensitive error:&error];
                     matches = [rsdURLRegExp matchesInString:responseString options:0 range:NSMakeRange(0, [responseString length])];
                 }
                 NSString *rsdURL = nil;


### PR DESCRIPTION
Refactor the ```guessXMLRPCURLForSite``` in four sub functions to make it easier to work on it.

How to test:

 - Run the unit tests and see if all of them are still green.

Needs Review: @koke 